### PR TITLE
Fix for invalid subscriptions

### DIFF
--- a/templates/remoteClass_constructors.ftm
+++ b/templates/remoteClass_constructors.ftm
@@ -51,6 +51,7 @@
     var count = EventEmitter.listenerCount(this, event);
     if(count) return;
 
+    if (!subscriptions.hasOwnProperty(event)) return;
     var token = subscriptions[event];
 
     var params =


### PR DESCRIPTION
When releasing a MediaObject, for example a PlayerEndpoint, there is no subscription on the server,
but the removeListener is called for 'EndOfStream'.
The subscriptions['EndOfStream'] does not exist and the token is invalid.
This fix prevents that the invalid 'token' is used, and that an Exception is raised.