### PR TITLE
Update package kurento-jsonrpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,16 +67,16 @@
     "async": "^2.0.1",
     "error-tojson": "0.0.1",
     "es6-promise": "^4.0.5",
-    "promise": "7.1.1",
     "extend": "^3.0.0",
     "inherits": "^2.0.3",
     "kurento-client-core": "^6.0.0",
     "kurento-client-elements": "^6.0.0",
     "kurento-client-filters": "^6.0.0",
-    "kurento-jsonrpc": "^6.0.0",
+    "kurento-jsonrpc": "git+https://github.com/yonghongren/kurento-jsonrpc-js.git",
+    "minimist": "^1.2.0",
+    "promise": "7.1.1",
     "promisecallback": "0.0.4",
-    "reconnect-ws": "KurentoForks/reconnect-ws#master",
-    "minimist": "^1.2.0"
+    "reconnect-ws": "KurentoForks/reconnect-ws#master"
   },
   "devDependencies": {
     "bower": "^1.0.0",


### PR DESCRIPTION
Update package kurento-jsonrpc-js so that it works with newer versions of Node.js that has 'ForceSet' removed from Native Abstraction for Node (nan).