### PR TITLE
Clear ping-pong timer when closing client.

### DIFF
--- a/lib/KurentoClient.js
+++ b/lib/KurentoClient.js
@@ -926,6 +926,10 @@ function KurentoClient(ws_uri, options, callback) {
     this.close = function () {
       closed = true;
 
+      enabledPings = false;
+      clearInterval(pingInterval);
+      pingPongStarted = false;
+
       prevRpc_result.then(re.disconnect.bind(re));
     };
 


### PR DESCRIPTION
This prevents hangs on application exit and addresses the issue [reported here](https://github.com/Kurento/bugtracker/issues/131).

Fixes https://github.com/Kurento/bugtracker/issues/131