### PR TITLE
removed error-tojson dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,6 @@
  * @license ALv2
  */
 
-require('error-tojson');
 
 var checkType = require('./checkType');
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "async": "^2.0.1",
-    "error-tojson": "0.0.1",
     "es6-promise": "^4.0.5",
     "promise": "7.1.1",
     "extend": "^3.0.0",


### PR DESCRIPTION
## What is the new behavior provided by this change?

In 2016 a library was added to help stringify errors for better debugging[1].

However, when analyzing the kurento-client-js code, such a library is not used anywhere. Not only that, it alters the Error globally, causing conflicts with other libraries, making it impossible to be used together with kurento, as it happens for example with axios. The library was also abandoned and has not been updated for another four years [2].

As the library, besides being outdated, is not used and conflicts with other libraries, the suggestion is that it be removed.

This discussion started in the kurento group [3].

1. https://github.com/Kurento/kurento-client-js/commit/6dc7a8cd8cf88317775c3212b755d3772386f72b#diff-6d186b954a58d5bb740f73d84fe39073

2. https://github.com/AVVS/error-tojson

3. https://groups.google.com/g/kurento/c/p_N_ITKoRtI


## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, tests ran to see how
your change affects other areas of the code, etc.
-->


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [x] I have written new tests for the changes, as applicable, and have successfully run them locally
