### PR TITLE
fix: remove lib error-tojson and add method locally to stringify error

### DIFF
--- a/lib/errorToJson.js
+++ b/lib/errorToJson.js
@@ -1,0 +1,13 @@
+Object.defineProperty(Error.prototype, 'toJSON', {
+  value: function () {
+    var alt = {};
+
+    Object.getOwnPropertyNames(this).forEach(function (key) {
+      alt[key] = this[key];
+    }, this);
+
+    return alt;
+  },
+  configurable: true,
+  writable: true,
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@
  * @license ALv2
  */
 
-require('error-tojson');
+require('./errorToJson');
 
 var checkType = require('./checkType');
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "async": "^2.0.1",
-    "error-tojson": "0.0.1",
     "es6-promise": "^4.0.5",
     "promise": "7.1.1",
     "extend": "^3.0.0",


### PR DESCRIPTION

## What is the current behavior you want to change?
As discussed [here](https://github.com/Kurento/kurento-client-js/pull/9#issuecomment-647427575), this code adds a new file that does what the error-tojson library (which has been removed) did, only without compatibility issues.


## What is the new behavior provided by this change?
Add errorToJson file to add toJSON method to stringify error 

## How has this been tested?
The simple way to test is to check if the toJSON method exists, then check if when called it generates an object with the stack and message attributes.

And to check if there is no more conflict, just try to add a new function for Error.prototipy.toJSON.

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
