### PR TITLE
fix errorToJson: SyntaxError: 'return' outside of function

### DIFF
--- a/lib/errorToJson.js
+++ b/lib/errorToJson.js
@@ -1,17 +1,15 @@
-if ("toJSON" in Error.prototype) {
-  return;
+if (!("toJSON" in Error.prototype)) {
+  Object.defineProperty(Error.prototype, "toJSON", {
+    value: function () {
+      var alt = {};
+
+      Object.getOwnPropertyNames(this).forEach(function (key) {
+        alt[key] = this[key];
+      }, this);
+
+      return alt;
+    },
+    configurable: true,
+    writable: true,
+  });
 }
-
-Object.defineProperty(Error.prototype, "toJSON", {
-  value: function () {
-    var alt = {};
-
-    Object.getOwnPropertyNames(this).forEach(function (key) {
-      alt[key] = this[key];
-    }, this);
-
-    return alt;
-  },
-  configurable: true,
-  writable: true,
-});


### PR DESCRIPTION
## What is the current behavior you want to change?
Bundling the client bundle via grunt has been broken since 8ecee3a89887056f41fdde892287b02eb3b570e1 with error:
`uglify-js failed on lib/errorToJson.js : SyntaxError: 'return' outside of function`

Webpack users are also no longer able to use the lib:
`SyntaxError: Illegal return statement`

## What is the new behavior provided by this change?
Quite simple - short-circuited return replaced with a block.
```diff
-if ("toJSON" in Error.prototype) {
-  return;
-}
-
+if (!("toJSON" in Error.prototype)) {
   Object.defineProperty(Error.prototype, "toJSON", {
     value: function () {
       var alt = {};

Object.defineProperty(Error.prototype, "toJSON", { 
12
     configurable: true,
     writable: true,
   });
+}
```

## How has this been tested?
```
cd kurento-client-js
npm i
./node_modules/.bin/grunt
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->

## Checklist
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [x] I have written new tests for the changes, as applicable, and have successfully run them locally